### PR TITLE
Fixing unit test failures

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -423,9 +423,9 @@ AuthenticationContext.prototype.acquireToken = function (resource, callback) {
     
     // refresh attept with iframe
     //Already renewing for this resource, callback when we get the token.
-    if ((this._activeRenewals[resource] || window.parent.AuthenticationContext()._activeRenewals[resource])
+    if ((this._activeRenewals[resource] || window.parent && (window.parent.AuthenticationContext()._activeRenewals[resource])
         && (window.loadframeStatus[resource] !== this.CONSTANTS.LOADFRAME_EXPIRED || window.parent.loadframeStatus[resource]
-        !== this.CONSTANTS.LOADFRAME_EXPIRED)) {
+        !== this.CONSTANTS.LOADFRAME_EXPIRED))) {
         //Active renewals contains the state for each renewal.
         this.registerCallback(this._activeRenewals[resource], resource, callback);
         this.verbose('acquireToken: register callback for ' + resource);
@@ -759,7 +759,9 @@ AuthenticationContext.prototype.saveTokenFromHash = function (requestInfo) {
                 // save token with related resource
                 this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN]);
                 this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, this._expiresIn(requestInfo.parameters[this.CONSTANTS.EXPIRES_IN]));
-                delete window.parent.loadframeStatus[resource];
+                if (window.parent && window.parent.loadframeStatus) {
+                    delete window.parent.loadframeStatus[resource];
+                }
                 this.verbose('token sucessfully updated in local storage. removing iframe session tracking for ' + resource);
             }
             
@@ -781,7 +783,9 @@ AuthenticationContext.prototype.saveTokenFromHash = function (requestInfo) {
                         }
                         this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
                         this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, this._user.profile.exp);
-                        delete window.parent.loadframeStatus[resource];
+                        if (window.parent && window.parent.loadframeStatus) {
+                            delete window.parent.loadframeStatus[resource];
+                        }
                         this.verbose('token sucessfully updated in local storage. removing iframe session tracking for ' +resource);
                     }
                 }

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -423,9 +423,9 @@ AuthenticationContext.prototype.acquireToken = function (resource, callback) {
     
     // refresh attept with iframe
     //Already renewing for this resource, callback when we get the token.
-    if ((this._activeRenewals[resource] || window.parent && (window.parent.AuthenticationContext()._activeRenewals[resource])
+    if ((this._activeRenewals[resource] || (window.parent && window.parent.AuthenticationContext()._activeRenewals[resource]))
         && (window.loadframeStatus[resource] !== this.CONSTANTS.LOADFRAME_EXPIRED || window.parent.loadframeStatus[resource]
-        !== this.CONSTANTS.LOADFRAME_EXPIRED))) {
+        !== this.CONSTANTS.LOADFRAME_EXPIRED)) {
         //Active renewals contains the state for each renewal.
         this.registerCallback(this._activeRenewals[resource], resource, callback);
         this.verbose('acquireToken: register callback for ' + resource);

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -207,7 +207,7 @@ describe('Adal', function () {
             token = valToken;
         };
         adal.acquireToken(null, callback);
-        expect(err).toBe('resource is required');
+        expect(err).toBe('acquireToken: resource is required');
     });
 
     it('returns err msg if token expired and renew failed before', function () {


### PR DESCRIPTION
The unit tests were failing because window.parent was null. Added in some null checks for window.parent.
