### PR TITLE
distinguish tokenRenewFailure

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -142,7 +142,7 @@ if (typeof module !== 'undefined' && module.exports) {
                                 _adal.acquireToken(_adal.config.loginResource, function (error, tokenOut) {
                                     if (error) {
                                         _isRenewingToken = false;
-                                        $rootScope.$broadcast('adal:loginFailure', 'auto renew failure ' + error);
+                                        $rootScope.$broadcast('adal:tokenRenewFailure', 'auto renew failure ' + error);
                                     } else {
                                         _isRenewingToken = false;
                                         if (tokenOut) {
@@ -239,6 +239,7 @@ if (typeof module !== 'undefined' && module.exports) {
                         _adal.acquireToken(resource, function (error, tokenOut) {
                             if (error) {
                                 _adal.error('Error when acquiring token for resource: ' + resource, error);
+                                $rootScope.$broadcast('adal:tokenRenewFailure', 'auto renew failure ' + error);
                                 deferred.reject(error);
                             } else {
                                 deferred.resolve(tokenOut);


### PR DESCRIPTION
right now token renew failures share the same event name as login failure, which is bad for diagnosis
