### PR TITLE
Add user role to user profile

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -32,7 +32,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
         AdalModule.provider('adalAuthenticationService', function () {
             var _adal = null;
-            var _oauthData = { isAuthenticated: false, userName: '', loginError: '', profile: '' };
+            var _oauthData = { isAuthenticated: false, userName: '', userRole: '', loginError: '', profile: '' };
             var _isOffline = null;
 
             var updateDataFromCache = function (resource) {
@@ -41,6 +41,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 _oauthData.isAuthenticated = token !== null && token.length > 0;
                 var user = _adal.getCachedUser() || { userName: '' };
                 _oauthData.userName = user.userName;
+				_oauthData.userRole = user.userRole;
                 _oauthData.profile = user.profile;
                 _oauthData.loginError = _adal.getLoginError();
             };

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -112,7 +112,17 @@ AuthenticationContext = function (config) {
             1: 'WARNING:',
             2: 'INFO:',
             3: 'VERBOSE:'
-        }
+        },
+		USERROLE: {
+			DEFAULT: 0,
+			GUEST: 1,
+			ANONYMOUS: 2
+		},
+		USERROLE_STRING_MAP: {
+			0: 'default',
+			1: 'guest',
+			2: 'anonymous'
+		}
     };
 
     if (AuthenticationContext.prototype._singletonInstance) {
@@ -607,8 +617,20 @@ AuthenticationContext.prototype._createUser = function (idToken) {
 
             user = {
                 userName: '',
-                profile: parsedJson
+                profile: parsedJson,
+				userRole: ''
             };
+			
+			if (parsedJson.hasOwnProperty('iss')) {
+				if (!parsedJson.hasOwnProperty('idp') || parsedJson.idp === parsedJson.iss) {
+					user.userRole = this.CONSTANTS.USERROLE.DEFAULT;
+				}
+				else {
+					if (parsedJson.idp !== user.profile.iss){
+						user.userRole = this.CONSTANTS.USERROLE.GUEST;
+					}
+				}
+			}
 
             if (parsedJson.hasOwnProperty('upn')) {
                 user.userName = parsedJson.upn;


### PR DESCRIPTION
Adding a User Role to user profile so you can sign in labeled as a default user to a tenant or a guest to a tenant.  Added an anonymous user role type for the future.
